### PR TITLE
[framework-research-solarb-15] graphql-spqr-spring-boot-starter 예제 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ allprojects {
 
     tasks.withType<Test>() {
         finalizedBy("jacocoTestReport")
+        systemProperty("spring.profiles.active", "test")
     }
 
     tasks.withType<JacocoReport> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,4 @@ kapt.incremental.apt=true
 # Increase the memory to run on GH Actions
 # See: https://github.com/gradle/gradle/issues/8139
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
+kotlin.incremental.useClasspathSnapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,8 @@ reactor-core = "3.5.9"
 reactor-extensions = "1.2.2"
 slf4j = "2.0.7"
 spring = "6.0.11"
-spring-boot = "3.2.0" # Nov 23, 2023
+#spring-boot = "3.2.0" # Nov 23, 2023
+spring-boot = "3.1.6" # Nov 23, 2023
 h2 = "2.2.224" # Sep 18, 2023
 graphql-kotlin = "7.0.2"
 
@@ -48,6 +49,7 @@ maven-plugin-development = "0.4.2"
 nexus-publish-plugin = "1.3.0"
 plugin-publish = "1.2.1"
 mariadb = "3.1.2"
+graphql-spqr = "1.0.0"
 # ====================
 # LIBRARIES
 # ====================
@@ -85,12 +87,13 @@ slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 spring-boot-config = { group = "org.springframework.boot", name = "spring-boot-configuration-processor", version.ref = "spring-boot" }
 spring-boot-netty = { group = "org.springframework.boot", name = "spring-boot-starter-reactor-netty", version.ref = "spring-boot" }
 spring-boot-webflux = { group = "org.springframework.boot", name = "spring-boot-starter-webflux", version.ref = "spring-boot" }
+spring-boot-web = { group = "org.springframework.boot", name = "spring-boot-starter-web", version.ref = "spring-boot" }
+spring-boot-websocket = { group = "org.springframework.boot", name = "spring-boot-starter-websocket", version.ref = "spring-boot" }
 spring-webflux = { group = "org.springframework", name = "spring-webflux", version.ref = "spring" }
 h2database = { group = "com.h2database", name = "h2", version.ref = "h2" }
 graphql-kotlin-spring-server = { group = "com.expediagroup", name = "graphql-kotlin-spring-server", version.ref = "graphql-kotlin" }
 graphql-kotlin-hooks-provider = { group = "com.expediagroup", name = "graphql-kotlin-hooks-provider", version.ref = "graphql-kotlin" }
-
-# test dependencies
+graphql-spqr-spring-boot = { group = "io.leangen.graphql", name = "graphql-spqr-spring-boot-starter", version.ref = "graphql-spqr" }# test dependencies
 compile-testing = { group = "dev.zacsweers.kctfork", name = "core", version.ref = "compile-testing" }
 icu = { group = "com.ibm.icu", name = "icu4j", version.ref = "icu" }
 logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }

--- a/graphql-kotlin-spring/build.gradle.kts
+++ b/graphql-kotlin-spring/build.gradle.kts
@@ -7,12 +7,17 @@ plugins {
     alias(libs.plugins.spring.boot)
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     implementation(libs.graphql.kotlin.spring.server)
     implementation(libs.graphql.kotlin.hooks.provider)
     implementation(libs.spring.boot.validation)
     implementation(libs.spring.boot.webflux)
     implementation(project(":module:entity"))
+    runtimeOnly(libs.mariadb.client)
 
     testImplementation(libs.h2database)
     testImplementation(libs.spring.boot.test)

--- a/graphql-spqr-spring-boot-starter/build.gradle.kts
+++ b/graphql-spqr-spring-boot-starter/build.gradle.kts
@@ -12,6 +12,7 @@ allOpen {
 
 dependencies {
     implementation(libs.spring.boot.web)
+    implementation(libs.spring.boot.webflux)
     implementation(libs.graphql.spqr.spring.boot)
     implementation(project(":module:entity"))
     runtimeOnly(libs.mariadb.client)

--- a/graphql-spqr-spring-boot-starter/build.gradle.kts
+++ b/graphql-spqr-spring-boot-starter/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
     alias(libs.plugins.spring.boot)
 }
 
+allOpen {
+    annotations("jakarta.persistence.Entity", "jakarta.persistence.MappedSuperclass", "jakarta.persistence.Embeddable")
+}
+
 dependencies {
     implementation(libs.spring.boot.web)
     implementation(libs.graphql.spqr.spring.boot)

--- a/graphql-spqr-spring-boot-starter/build.gradle.kts
+++ b/graphql-spqr-spring-boot-starter/build.gradle.kts
@@ -1,0 +1,17 @@
+description = "An example GraphQL SPQR Spring Boot Starter"
+
+plugins {
+    id("com.ignite.graphql.examples.conventions")
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+dependencies {
+    implementation(libs.spring.boot.web)
+    implementation(libs.graphql.spqr.spring.boot)
+    implementation(project(":module:entity"))
+    runtimeOnly(libs.mariadb.client)
+
+    testImplementation(libs.h2database)
+    testImplementation(libs.spring.boot.test)
+}

--- a/graphql-spqr-spring-boot-starter/src/main/kotlin/com/ignite/solarb/graphqlspqr/GraphqlSpqrApplication.kt
+++ b/graphql-spqr-spring-boot-starter/src/main/kotlin/com/ignite/solarb/graphqlspqr/GraphqlSpqrApplication.kt
@@ -1,0 +1,15 @@
+package com.ignite.solarb.graphqlspqr
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@SpringBootApplication
+@EnableJpaRepositories(basePackages = ["com.ignite.research"])
+@EntityScan(basePackages = ["com.ignite.research"])
+class GraphqlSpqrApplication
+
+fun main(args: Array<String>) {
+    runApplication<GraphqlSpqrApplication>(*args)
+}

--- a/graphql-spqr-spring-boot-starter/src/main/kotlin/com/ignite/solarb/graphqlspqr/GraphqlSpqrController.kt
+++ b/graphql-spqr-spring-boot-starter/src/main/kotlin/com/ignite/solarb/graphqlspqr/GraphqlSpqrController.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Controller
 
 @GraphQLApi
 @Controller
-class GraphqlSpqrService(
+class GraphqlSpqrController(
     val boardRepository: BoardRepository,
     val commentRepository: CommentRepository,
     var userRepository: UserRepository

--- a/graphql-spqr-spring-boot-starter/src/main/kotlin/com/ignite/solarb/graphqlspqr/GraphqlSpqrService.kt
+++ b/graphql-spqr-spring-boot-starter/src/main/kotlin/com/ignite/solarb/graphqlspqr/GraphqlSpqrService.kt
@@ -1,0 +1,66 @@
+package com.ignite.solarb.graphqlspqr
+
+import com.ignite.research.*
+import io.leangen.graphql.annotations.GraphQLContext
+import io.leangen.graphql.annotations.GraphQLMutation
+import io.leangen.graphql.annotations.GraphQLQuery
+import io.leangen.graphql.spqr.spring.annotations.GraphQLApi
+import org.springframework.stereotype.Controller
+
+@GraphQLApi
+@Controller
+class GraphqlSpqrService(
+    val boardRepository: BoardRepository,
+    val commentRepository: CommentRepository,
+    var userRepository: UserRepository
+) {
+    @GraphQLQuery
+    fun board(boardId: Long): Board {
+        return boardRepository.findById(boardId).orElseThrow()
+    }
+
+    @GraphQLQuery
+    fun boards(): List<Board> {
+        return boardRepository.findAll()
+    }
+
+    @GraphQLQuery
+    fun comment(commentId: Long): Comment {
+        return commentRepository.findById(commentId).orElseThrow()
+    }
+
+    @GraphQLQuery
+    fun comments(): List<Comment> {
+        return commentRepository.findAll()
+    }
+
+    @GraphQLQuery
+    fun comments(@GraphQLContext board: Board): List<Comment> {
+        return commentRepository.findByBoard(board)
+    }
+
+    @GraphQLQuery
+    fun user(userId: Long): User {
+        return userRepository.findById(userId).orElseThrow()
+    }
+
+    @GraphQLQuery
+    fun users(): List<User> {
+        return userRepository.findAll()
+    }
+
+    @GraphQLMutation
+    fun board(board: Board): Long {
+        return boardRepository.save(board).id!!
+    }
+
+    @GraphQLMutation
+    fun comment(comment: Comment): Long {
+        return commentRepository.save(comment).id!!
+    }
+
+    @GraphQLMutation
+    fun user(user: User): Long {
+        return userRepository.save(user).id!!
+    }
+}

--- a/graphql-spqr-spring-boot-starter/src/main/resources/application.yml
+++ b/graphql-spqr-spring-boot-starter/src/main/resources/application.yml
@@ -13,11 +13,6 @@ spring:
     password: research
 
 graphql:
-  packages:
-    - "com.ignite.graphql.examples.server.spring"
-  playground:
-    enabled: true
-  subscriptions:
-    # Send a ka message every 1000 ms (1 second)
-    keepAliveInterval: 1000
-    protocol: "APOLLO_SUBSCRIPTIONS_WS"
+  spqr:
+    gui:
+      enabled: true

--- a/graphql-spqr-spring-boot-starter/src/test/java/com/ignite/solarb/graphqlspqr/GraphqlSpqrControllerTest.kt
+++ b/graphql-spqr-spring-boot-starter/src/test/java/com/ignite/solarb/graphqlspqr/GraphqlSpqrControllerTest.kt
@@ -1,0 +1,118 @@
+package com.ignite.solarb.graphqlspqr
+
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import reactor.core.publisher.Mono
+import kotlin.test.Test
+
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [GraphqlSpqrApplication::class]
+)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class GraphqlSpqrControllerTest(
+    @Autowired
+    private val webTestClient: WebTestClient
+) {
+    private val GRAPHQL_PATH = "/graphql"
+
+    @Test
+    @Order(1)
+    fun board() {
+        val query = """ {board(boardId: 2) { id title comments { id }}} """
+        val expectedJSON = """ {"data":{"board":{"id":2,"title":"board title 2","comments":[{"id":3},{"id":4}]}}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+
+    @Test
+    @Order(1)
+    fun boards() {
+        val query = """ {boards { id }} """
+        val expectedJSON = """ {"data":{"boards":[{"id":1},{"id":2}]}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(1)
+    fun comments() {
+        val query = """ {comments { id }} """
+        val expectedJSON = """ {"data":{"comments":[{"id":1},{"id":2},{"id":3},{"id":4}]}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(1)
+    fun comment() {
+        val query = """ {comment(commentId: 3) { id content board { id }}} """
+        val expectedJSON = """ {"data":{"comment":{"id":3,"content":"comment content 3","board":{"id":2}}}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(1)
+    fun users() {
+        val query = """ {users { id }} """
+        val expectedJSON = """ {"data":{"users":[{"id":1},{"id":2}]}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(1)
+    fun user() {
+        val query = """ {user(userId: 1) { id name}} """
+        val expectedJSON = """ {"data":{"user":{"id":1,"name":"name 1"}}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(2)
+    fun mutationBoard() {
+        val query = """ mutation {board(board: {title: "title 3", content: "content: 3"})} """
+        val expectedJSON = """ {"data":{"board":3}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(2)
+    fun mutationComment() {
+        val query = """ mutation {comment(comment: {board: {id: 1}, content: "content: 5"})} """
+        val expectedJSON = """ {"data":{"comment":5}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    @Test
+    @Order(2)
+    fun mutationUser() {
+        val query = """ mutation {user(user: {name: "name 3"})} """
+        val expectedJSON = """ {"data":{"user":3}} """
+        expectQueryResult(query, expectedJSON)
+    }
+
+    private fun expectQueryResult(query: String, expectedJSON: String) {
+        webTestClient.post()
+            .uri(GRAPHQL_PATH)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(Mono.just(toJSON(query)), String::class.java)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody().json(
+                expectedJSON, false
+            )
+    }
+
+    private fun toJSON(query: String): String {
+        return try {
+            JSONObject().put("query", query).toString()
+        } catch (e: JSONException) {
+            throw RuntimeException(e)
+        }
+    }
+}

--- a/graphql-spqr-spring-boot-starter/src/test/resources/application-test.properties
+++ b/graphql-spqr-spring-boot-starter/src/test/resources/application-test.properties
@@ -1,5 +1,7 @@
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_UPPER=FALSE
 spring.datasource.username=sa
 spring.datasource.password=
+spring.jpa.show-sql=true
+#spring.jpa.properties.hibernate.format_sql=true

--- a/graphql-spqr-spring-boot-starter/src/test/resources/data.sql
+++ b/graphql-spqr-spring-boot-starter/src/test/resources/data.sql
@@ -1,0 +1,21 @@
+insert into `board` (id, title, content, created_at, updated_at, created_by, updated_by)
+values (1, 'board title', 'board content', now(), now(), '', ''),
+       (2, 'board title 2', 'board content 2', now(), now(), '', '');
+ALTER TABLE board
+    AUTO_INCREMENT = 3;
+
+insert into `comment`(id, board_id, content, parent_id, created_at, updated_at, created_by, updated_by)
+values (1, 1, 'comment content 1', null, now(), now(), '', ''),
+       (2, 1, 'comment content 2', null, now(), now(), '', ''),
+       (3, 2, 'comment content 3', null, now(), now(), '', ''),
+       (4, 2, 'comment content 4', null, now(), now(), '', '');
+
+ALTER TABLE comment
+    AUTO_INCREMENT = 5;
+
+insert into `user` (id, user_id, name, password, created_at, updated_at, created_by, updated_by)
+values (1, 'user id 1', 'name 1', 'password 1', now(), now(), '', ''),
+       (2, 'user id 2', 'name 2', 'password 2', now(), now(), '', '');
+
+ALTER TABLE `user`
+    AUTO_INCREMENT = 3;

--- a/module/entity/build.gradle.kts
+++ b/module/entity/build.gradle.kts
@@ -22,7 +22,3 @@ dependencies {
     testImplementation(libs.spring.boot.test)
     testImplementation(libs.kotlin.junit.test)
 }
-
-tasks.test {
-    systemProperty("spring.profiles.active", "test")
-}

--- a/module/entity/build.gradle.kts
+++ b/module/entity/build.gradle.kts
@@ -1,17 +1,14 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-
 description = "entity module"
 
 plugins {
     id("com.ignite.graphql.examples.conventions")
     alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.spring.boot)
     alias(libs.plugins.kotlin.jpa)
     `java-library`
 }
 
-tasks.named<BootJar>("bootJar") {
-    isEnabled = false
+tasks.jar {
+    enabled = true
 }
 
 allOpen {

--- a/module/entity/src/main/kotlin/com/ignite/research/domain.kt
+++ b/module/entity/src/main/kotlin/com/ignite/research/domain.kt
@@ -60,8 +60,9 @@ class Comment : PrimaryKeyEntity() {
     var audit: Audit = Audit()
 }
 
-interface CommentRepository : JpaRepository<Comment, Long>
-
+interface CommentRepository : JpaRepository<Comment, Long> {
+    fun findByBoard(board: Board): List<Comment>
+}
 
 @Entity(name = "`user`")
 class User(

--- a/module/entity/src/test/kotlin/com/ignite/research/Application.kt
+++ b/module/entity/src/test/kotlin/com/ignite/research/Application.kt
@@ -2,12 +2,10 @@ package com.ignite.research
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.context.annotation.Profile
 
 @SpringBootApplication
-@Profile("test")
-class EntityTestApplication
+class Application
 
 fun main(args: Array<String>) {
-    runApplication<EntityTestApplication>(*args)
+    runApplication<Application>(*args)
 }

--- a/module/jpa/build.gradle.kts
+++ b/module/jpa/build.gradle.kts
@@ -22,7 +22,3 @@ dependencies {
 tasks.jar {
     enabled = true
 }
-
-tasks.test {
-    systemProperty("spring.profiles.active", "test")
-}

--- a/module/jpa/build.gradle.kts
+++ b/module/jpa/build.gradle.kts
@@ -1,11 +1,8 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-
 description = "jpa module"
 
 plugins {
     id("com.ignite.graphql.examples.conventions")
     alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.spring.boot)
     `java-library`
 }
 
@@ -13,16 +10,17 @@ kotlin {
     jvmToolchain(17)
 }
 
-tasks.named<BootJar>("bootJar") {
-    isEnabled = false
-}
-
 dependencies {
     api(libs.spring.boot.starter.data.jpa)
     runtimeOnly(libs.mariadb.client)
 
+    testImplementation(libs.kotlin.junit.test)
     testImplementation(libs.h2database)
     testImplementation(libs.spring.boot.test)
+}
+
+tasks.jar {
+    enabled = true
 }
 
 tasks.test {

--- a/module/jpa/src/main/kotlin/com/ignite/entity/TestApplication.kt
+++ b/module/jpa/src/main/kotlin/com/ignite/entity/TestApplication.kt
@@ -2,12 +2,10 @@ package com.ignite.entity
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.context.annotation.Profile
 
 @SpringBootApplication
-@Profile("test")
-class AccessingDataJpaApplication
+class TestApplication
 
 fun main(args: Array<String>) {
-    runApplication<AccessingDataJpaApplication>(*args)
+    runApplication<TestApplication>(*args)
 }

--- a/module/jpa/src/test/kotlin/com/ignite/entity/CustomerCommandLineRunner.kt
+++ b/module/jpa/src/test/kotlin/com/ignite/entity/CustomerCommandLineRunner.kt
@@ -7,9 +7,9 @@ import java.util.function.Consumer
 
 @Component
 class CustomerCommandLineRunner(
-    val repository: CustomerRepository
+    val repository: CustomerRepository,
 ) : CommandLineRunner {
-    private val log = LoggerFactory.getLogger(AccessingDataJpaApplication::class.java)
+    private val log = LoggerFactory.getLogger(CustomerCommandLineRunner::class.java)
     override fun run(vararg args: String?) {
         // save a few customers
         repository.save(Customer("Jack", "foo"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "framework-research-solarb"
 
-include(":graphql-kotlin-spring")
-include(":module:jpa")
-include(":module:entity")
+include("graphql-kotlin-spring")
+include("module:jpa")
+include("module:entity")
+include("graphql-spqr-spring-boot-starter")


### PR DESCRIPTION
close #15 

- 조회/저장 적용

module dependency -plain.jar 로 조회 (jpa-0.0.1-SNAPSHOT-plain.jar)
- 실제 파일은 -plain 이 없는 상태로 생성된 상태
- gradle.properties 적용시 정상 동작
```
kotlin.incremental.useClasspathSnapshot=false
```

Springboot plugin 사용하는 경우 jar task disabled 됨
- bootjar 통해 jar 파일 생성 되지만 class 파일 참조 되지 않음.
- tasks.jar { enabled = true } 적용시 정상 동작

Cannot resolve parameter names for constructor public io.leangen.graphql.spqr.spring.web.dto.GraphQLRequest
- compile 된 파일에 메타정보가 없어 발생하는 오류라고 하나 vm option 적용으로도 조치 되지 않음
```
tasks.withType<KotlinCompile> {
    kotlinOptions {
        freeCompilerArgs = listOf("-java-parameters")
    }
}
```
- spring-boot 3.2.0 -> 3.1.6 으로 변경 적용시 정상 동작

